### PR TITLE
Temporary workaround the FileNotFound exception that happens when

### DIFF
--- a/ChaosTestApplication/ChaosTest.ChaosService/ChaosService.cs
+++ b/ChaosTestApplication/ChaosTest.ChaosService/ChaosService.cs
@@ -307,7 +307,7 @@ namespace ChaosTest.ChaosService
                 return;
             }
 
-            this.StoreEventAsync(eventString).Wait();
+            this.StoreEventAsync(eventString).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/ChaosTestApplication/ChaosTest.ChaosService/Program.cs
+++ b/ChaosTestApplication/ChaosTest.ChaosService/Program.cs
@@ -7,12 +7,17 @@ namespace ChaosTest.ChaosService
 {
     using System;
     using System.Diagnostics;
+    using System.IO;
+    using System.Reflection;
     using System.Threading;
     using ChaosTest.Common;
     using Microsoft.ServiceFabric.Services.Runtime;
 
     public class Program
     {
+        private const string FabricCodePath = @"C:\Program Files\Microsoft Service Fabric\bin\Fabric\Fabric.Code";
+        private const string ServiceModelAssemblyName = "System.Fabric.Management.ServiceModel";
+
         public static void Main(string[] args)
         {
             try
@@ -21,6 +26,8 @@ namespace ChaosTest.ChaosService
                     StringResource.ChaosTestServiceType,
                     context =>
                         new ChaosService(context)).GetAwaiter().GetResult();
+
+                AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(LoadFromFabricCodePath);
 
                 ServiceEventSource.Current.ServiceTypeRegistered(Process.GetCurrentProcess().Id, typeof(ChaosService).Name);
 
@@ -35,5 +42,32 @@ namespace ChaosTest.ChaosService
                 throw;
             }
         }
+
+        private static Assembly LoadFromFabricCodePath(object sender, ResolveEventArgs args)
+        {
+            string assemblyName = new AssemblyName(args.Name).Name;
+
+            if (!assemblyName.Equals(ServiceModelAssemblyName))
+            {
+                return null;
+            }
+
+            try
+            {
+                string assemblyPath = Path.Combine(FabricCodePath, assemblyName + ".dll");
+                if (File.Exists(assemblyPath))
+                {
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+            }
+            catch (Exception)
+            {
+                // Suppress any Exception so that we can continue to
+                // load the assembly through other means
+            }
+
+            return null;
+        }
+
     }
 }

--- a/ChaosTestApplication/ChaosTest.Common/HttpExceptionHandler.cs
+++ b/ChaosTestApplication/ChaosTest.Common/HttpExceptionHandler.cs
@@ -35,7 +35,7 @@ namespace ChaosTest.Common
 
             if (httpException != null)
             {
-                result = new ExceptionHandlingThrowResult();
+                result = new ExceptionHandlingRetryResult(exceptionInformation.Exception, false, retrySettings, retrySettings.DefaultMaxRetryCount);
                 return true;
             }
 


### PR DESCRIPTION
System.Fabric tries to load System.Fabric.Management.ServiceModel
assembly.